### PR TITLE
handling zips starting with zero, of type int

### DIFF
--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -105,7 +105,7 @@ class ZipCodeDatabase(object):
         return format_result(self.conn_manager.query(ZIP_QUERY, (zip_code,)))
 
     def __getitem__(self, zip_code):
-        zip_code = self.get(str(zip_code))
+        zip_code = self.get(str(zip_code).zfill(5))
         if zip_code is None:
             raise IndexError("Couldn't find ZIP")
         else:

--- a/pyzipcode/tests.py
+++ b/pyzipcode/tests.py
@@ -12,7 +12,15 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEqual(zip.zip, '54115')
         self.assertEqual(zip.place, "De Pere")
         self.assertEqual(zip.state, "WI")
-        
+
+    def test_zip_code_starts_with_zero(self):
+        zip_code = '04330'
+        zip = self.db[zip_code]
+        self.assertEqual(zip.place, "Augusta")
+
+        zip = self.db[int(zip_code)]
+        self.assertEqual(zip.place, "Augusta")
+
     def test_correct_latitude_value(self):
         zip = self.db[54115]
         self.assertTrue(44.43 < zip.latitude < 44.44)


### PR DESCRIPTION
The documentation in the README.md implies that using an `int` to get a zip_code is a valid type, ie `zcdb[10013]`.  That is problematic if the zip starts with a zero, and thus results in a four digit int.  ie `zcdb[int(04330)]` will not work.

I found where that was cast to `str()` and then zeropadded the beginning of it.  That solves the situation I outlined above. I wrote a test to prove it as well.

Enjoy!